### PR TITLE
fix: buffer start offset

### DIFF
--- a/src/markers/exif.js
+++ b/src/markers/exif.js
@@ -256,7 +256,7 @@ class IDFEntries {
     const { exifIFDPointer, gpsInfoIFDPointer } = entries;
 
     if (exifIFDPointer) {
-      buffer = buffer.slice(exifIFDPointer - offsetToFirstIFD);
+      buffer = buffer.slice(exifIFDPointer - 8);
       entries.subExif = this._decodeIDFEntries(
         buffer,
         tags.ifd,

--- a/src/markers/exif.js
+++ b/src/markers/exif.js
@@ -251,7 +251,8 @@ class IDFEntries {
       return {};
     }
 
-    const entries = this._decodeIDFEntries(buffer, tags.ifd, offsetToFirstIFD);
+    const firstIFDBuffer = buffer.slice(offsetToFirstIFD - 8);
+    const entries = this._decodeIDFEntries(firstIFDBuffer, tags.ifd, offsetToFirstIFD);
     const { exifIFDPointer, gpsInfoIFDPointer } = entries;
 
     if (exifIFDPointer) {


### PR DESCRIPTION
### Issue

EXIF standard asserts that initial IFD are located at start of TIFF header + offsetToFirstIFD, and exif IDF is located at start of TIFF header + exifIFDPointer. This PR 

### Changes

Adjusts the offset logic in accordance to the standard.

### Validating the fix

jay-peg previously could not parse the EXIF data of https://oceanpacificlighting.xologic.com/vendors/205/large/531-GA.jpg with lots of attributes missing, but now includes these extra attributes.

There's still rooms for improvement, for which I am currently investigating. For example here's a snippet of parsed output.

```
        "focalPlaneXResolution": [
          NaN,
        ],
        "focalPlaneYResolution": [
          NaN,
        ],
        "lightSource": 0,
        "maxApertureValue": [
          NaN,
        ],
        "meteringMode": 0,
        "photographicSensitivity": 100,
        "pixelXDimension": 1656,
        "pixelYDimension": 4000,
```

Nonetheless I feel that the PR is an improvement, as before attributes such as "focalPlaneXResolution" were not even present in the output.

Partially fixes https://github.com/diegomura/react-pdf/issues/2639