### PR TITLE
fix: handle data after EOI

### DIFF
--- a/src/markers/eoi.js
+++ b/src/markers/eoi.js
@@ -1,5 +1,8 @@
+import * as r from "restructure";
+
 const EndOfImageMarker = {
   name: () => "EOI",
+  afterEOI: new r.Reserved(r.uint8, Infinity),
 };
 
 export default EndOfImageMarker;


### PR DESCRIPTION
### Issue

Certain image has Data after EOI and currently jay-peg throws `Unknown Version Number` exception when decoding these images

### Fix

Add `reserved` attribute in `EndOfImageMarker` so `restructure` expects potential data after EOI and does not crash.

### Validating the fix

https://github.com/exiftool/exiftool/blob/master/t/images/AFCP.jpg contains data after EOI. jay-peg threw `Unknown Version Number` exception without the fix, and decodes the image successfully after the fix.

Fixes #6