### PR TITLE
Do not mutate image buffer

### DIFF
--- a/src/markers/exif.js
+++ b/src/markers/exif.js
@@ -247,7 +247,7 @@ class IDFEntries {
 
       const tagNumber = this.bigEndian
         ? uint8ArrayToHexString(tagAddress)
-        : uint8ArrayToHexString(tagAddress.reverse());
+        : uint8ArrayToHexString(new Uint8Array(tagAddress).reverse());
 
       const tagName = tags[tagNumber];
 


### PR DESCRIPTION
`reverse` is a mutable function, we should copy the `Uint8Array`  before reversing.

This fixes the react-pdf exif problem being rendered wrong every two renders.

Fixes https://github.com/diegomura/react-pdf/issues/2972