### PR TITLE
fix: decode APP0 segments using declared segment length

### DIFF
--- a/src/markers/jfif.js
+++ b/src/markers/jfif.js
@@ -1,15 +1,98 @@
 import * as r from "restructure";
+import { readUInt16BE, uint8ArrayToString } from "./utils.js";
+
+const APP0_LENGTH_BYTES = 2;
+const JFIF_IDENTIFIER = "JFIF\0";
+const JFXX_IDENTIFIER = "JFXX\0";
+const JFIF_HEADER_LENGTH = 14;
+const JFXX_HEADER_LENGTH = 6;
+
+// APP0's name and fields depend on the payload contents (JFIF, JFXX, or
+// unknown), so they are written onto the marker directly to preserve the
+// original flat output shape.
+class APP0Payload {
+  decode(stream, parent) {
+    const payloadLength = parent.length - APP0_LENGTH_BYTES;
+
+    if (payloadLength < 0) {
+      throw new Error(`Invalid APP0 length ${parent.length}`);
+    }
+
+    const end = stream.pos + payloadLength;
+
+    if (end > stream.length) {
+      throw new Error(
+        `Truncated APP0 segment: declared length ${parent.length} exceeds remaining buffer`,
+      );
+    }
+
+    const payload = stream.buffer.slice(stream.pos, end);
+    stream.pos = end;
+
+    parent.name = "APP0";
+
+    if (payload.length === 0) {
+      return;
+    }
+
+    const identifierLength = Math.min(5, payload.length);
+    const identifier = uint8ArrayToString(payload.slice(0, identifierLength));
+
+    parent.identifier = identifier;
+
+    if (
+      identifier === JFIF_IDENTIFIER &&
+      payload.length >= JFIF_HEADER_LENGTH
+    ) {
+      parent.name = "JFIF";
+      parent.version = readUInt16BE(payload, 5);
+      parent.units = payload[7];
+      parent.xDensity = readUInt16BE(payload, 8);
+      parent.yDensity = readUInt16BE(payload, 10);
+      parent.thumbnailWidth = payload[12];
+      parent.thumbnailHeight = payload[13];
+
+      const thumbnailLength =
+        parent.thumbnailWidth * parent.thumbnailHeight * 3;
+      const thumbnailEnd = Math.min(
+        JFIF_HEADER_LENGTH + thumbnailLength,
+        payload.length,
+      );
+
+      if (thumbnailEnd > JFIF_HEADER_LENGTH) {
+        parent.thumbnail = payload.slice(JFIF_HEADER_LENGTH, thumbnailEnd);
+      }
+
+      if (payload.length > thumbnailEnd) {
+        parent.data = payload.slice(thumbnailEnd);
+      }
+
+      return;
+    }
+
+    if (identifier === JFXX_IDENTIFIER) {
+      parent.name = "JFXX";
+
+      if (payload.length >= JFXX_HEADER_LENGTH) {
+        parent.extensionCode = payload[5];
+      }
+
+      if (payload.length > JFXX_HEADER_LENGTH) {
+        parent.data = payload.slice(JFXX_HEADER_LENGTH);
+      }
+
+      return;
+    }
+
+    if (payload.length > identifierLength) {
+      parent.data = payload.slice(identifierLength);
+    }
+  }
+}
 
 const JFIFMarker = {
-  name: () => "JFIF",
   length: r.uint16be,
-  identifier: new r.String(5),
-  version: r.uint16be,
-  units: r.uint8,
-  xDensity: r.uint16be,
-  yDensity: r.uint16be,
-  thumbnailWidth: r.uint8,
-  thumbnailHeight: r.uint8,
+  payload: new APP0Payload(),
 };
 
 export default JFIFMarker;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -7,8 +7,10 @@ import JPEG from "../src";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const images = fs.readdirSync(`${__dirname}/images`);
-const nonPassingImages = ["ExifTool.jpg"];
-const passingImages = images.filter(image => !nonPassingImages.includes(image));
+const bufferTypes = [
+  ["Buffer", (bytes) => Buffer.from(bytes)],
+  ["Uint8Array", (bytes) => Uint8Array.from(bytes)],
+];
 
 expect.addSnapshotSerializer({
   serialize: (val) => Buffer.from(val).toString("hex"),
@@ -16,7 +18,7 @@ expect.addSnapshotSerializer({
 });
 
 describe("decode w/buffers", () => {
-  it.each(passingImages)("%s", (image) => {
+  it.each(images)("%s", (image) => {
     const buffer = fs.readFileSync(`${__dirname}/images/${image}`);
     const markers = JPEG.decode(buffer);
 
@@ -25,10 +27,111 @@ describe("decode w/buffers", () => {
 });
 
 describe("decode w/int arrays", () => {
-  it.each(passingImages)("%s", (image) => {
+  it.each(images)("%s", (image) => {
     const buffer = fs.readFileSync(`${__dirname}/images/${image}`);
     const markers = JPEG.decode(new Uint8Array(buffer));
 
     expect(markers).toMatchSnapshot();
   });
+});
+
+describe("APP0 markers", () => {
+  it.each(bufferTypes)(
+    "consumes extra JFIF bytes before the next marker w/%s",
+    (_, toBuffer) => {
+      const buffer = toBuffer([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x14, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+        0x01, 0x01, 0x01, 0x2c, 0x01, 0x2c, 0x00, 0x00, 0x41, 0x4d, 0x50, 0x46,
+        0xff, 0xe1, 0x00, 0x12, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00, 0x4d, 0x4d,
+        0x00, 0x2a, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0xff, 0xd9,
+      ]);
+
+      const markers = JPEG.decode(buffer);
+
+      expect(markers[1].name).toBe("JFIF");
+      expect(markers[1].length).toBe(20);
+      expect(Array.from(markers[1].data)).toEqual([0x41, 0x4d, 0x50, 0x46]);
+      expect(markers[2].type).toBe(0xffe1);
+      expect(markers[2].name).toBe("EXIF");
+      expect(markers[2].entries).toEqual({});
+      expect(markers[3].type).toBe(0xffd9);
+    },
+  );
+
+  it.each(bufferTypes)("consumes JFIF thumbnail bytes w/%s", (_, toBuffer) => {
+    const buffer = toBuffer([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x13, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+      0x02, 0x01, 0x00, 0x48, 0x00, 0x48, 0x01, 0x01, 0xff, 0x80, 0x00, 0xff,
+      0xd9,
+    ]);
+
+    const markers = JPEG.decode(buffer);
+
+    expect(markers[1].name).toBe("JFIF");
+    expect(markers[1].thumbnailWidth).toBe(1);
+    expect(markers[1].thumbnailHeight).toBe(1);
+    expect(Array.from(markers[1].thumbnail)).toEqual([0xff, 0x80, 0x00]);
+    expect(markers[2].type).toBe(0xffd9);
+  });
+
+  it.each(bufferTypes)("consumes JFXX payloads w/%s", (_, toBuffer) => {
+    const buffer = toBuffer([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x09, 0x4a, 0x46, 0x58, 0x58, 0x00, 0x10,
+      0xaa, 0xff, 0xd9,
+    ]);
+
+    const markers = JPEG.decode(buffer);
+
+    expect(markers[1].type).toBe(0xffe0);
+    expect(markers[1].name).toBe("JFXX");
+    expect(markers[1].extensionCode).toBe(0x10);
+    expect(Array.from(markers[1].data)).toEqual([0xaa]);
+    expect(markers[2].type).toBe(0xffd9);
+  });
+
+  it.each(bufferTypes)("consumes empty APP0 segments w/%s", (_, toBuffer) => {
+    const buffer = toBuffer([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x02, 0xff, 0xd9]);
+
+    const markers = JPEG.decode(buffer);
+
+    expect(markers[1].type).toBe(0xffe0);
+    expect(markers[1].name).toBe("APP0");
+    expect(markers[1].length).toBe(2);
+    expect(markers[1].identifier).toBeUndefined();
+    expect(markers[2].type).toBe(0xffd9);
+  });
+
+  it.each(bufferTypes)(
+    "throws on APP0 lengths smaller than the length field w/%s",
+    (_, toBuffer) => {
+      const buffer = toBuffer([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01, 0xff, 0xd9]);
+
+      expect(() => JPEG.decode(buffer)).toThrow("Invalid APP0 length 1");
+    },
+  );
+
+  it.each(bufferTypes)(
+    "throws on truncated APP0 payloads w/%s",
+    (_, toBuffer) => {
+      const buffer = toBuffer([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x14, 0x4a, 0x46, 0x49, 0x46, 0x00,
+      ]);
+
+      expect(() => JPEG.decode(buffer)).toThrow(
+        "Truncated APP0 segment: declared length 20 exceeds remaining buffer",
+      );
+    },
+  );
+
+  it.each(bufferTypes)(
+    "decodes the existing ExifTool APP0 fixture w/%s",
+    (_, toBuffer) => {
+      const buffer = fs.readFileSync(`${__dirname}/images/ExifTool.jpg`);
+      const markers = JPEG.decode(toBuffer(buffer));
+
+      expect(markers.some((marker) => marker.name === "JFXX")).toBe(true);
+      expect(markers.some((marker) => marker.name === "APP0")).toBe(true);
+      expect(markers.at(-1).type).toBe(0xffd9);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Fix APP0/JFIF decoding so jay-peg consumes the full APP0 segment payload described by the JPEG segment length, instead of assuming the canonical fixed-size JFIF header is the entire segment.

Previously, any APP0 bytes beyond the fixed-size JFIF struct (thumbnails, JFXX payloads, trailing data) were left in the stream, so the parser desynchronized and misread the next marker:

- JPEGs produced from iOS/Apple HEIC conversion carry trailing Apple MPF bytes (`AMPF`) in the APP0/JFIF segment before APP1/Exif. The leftover `0x414d` (`AM`) was read as the next marker type and decode failed with `Unknown version 16717`.
- The existing `tests/images/ExifTool.jpg` fixture (which carries a JFXX segment) failed the same way with `Unknown version 1542`, which is why it was excluded from the snapshot suite.

Fixes #21. Fixes #9 — the first regression test below embeds the exact segment bytes reported there. Also implements the JFXX parsing requested in #17: the extension code and raw payload are exposed (`extensionCode`, `data`), though thumbnail contents aren't further decoded.

This failure mode also surfaces downstream when react-pdf embeds JPEGs: diegomura/react-pdf#2734 reports `Unknown version` errors thrown from this same decode path for images that render fine elsewhere, which is likely this desync.

## What changed

- Decode APP0 as a length-framed payload, advancing the stream by the declared segment length — the same approach `exif.js` already uses for APP1.
- Preserve the existing JFIF fields for `JFIF\0` payloads; expose thumbnail bytes as `thumbnail` and any extra trailing bytes as `data`.
- Handle `JFXX\0` payloads (`name: "JFXX"`, `extensionCode`, `data`) without desynchronizing the stream.
- Preserve unknown APP0 payloads as `APP0` with their `identifier` and raw `data`.
- Throw descriptive errors for malformed segments: `Invalid APP0 length N` when the declared length is smaller than the 2 length bytes themselves, and `Truncated APP0 segment: declared length N exceeds remaining buffer` when it points past the end of the input.

## Behavior notes

- **Output compatibility:** all 122 pre-existing snapshot entries are byte-identical. The snapshot diff only *adds* the two new `ExifTool.jpg` entries.
- The legacy JFIF `type` behavior is intentionally preserved to avoid output churn: JFIF markers still expose the JFIF version in `type` after `decode()` maps the internal `version` field. This quirk is pre-existing on `main` (the old struct's `version` field had the same collision) — happy to address it in a follow-up if you'd like.
- Truncated/invalid APP0 segments now throw a descriptive error up front; previously they produced garbage field values or an opaque restructure error downstream. Well-formed input is unaffected.

## Tests

- `ExifTool.jpg` is re-enabled in the full snapshot suite (the `nonPassingImages` exclusion list is now empty and removed); it decodes through JFXX/APP0 all the way to EOI.
- Focused APP0 unit tests, each run against both `Buffer` and `Uint8Array` inputs:
  - `JFIF ... AMPF` followed by APP1/Exif, matching the reported failure mode (segment bytes from #9)
  - JFIF thumbnail payload consumption
  - JFXX payload consumption
  - empty APP0 segments (declared length of exactly 2)
  - APP0 lengths smaller than the length field itself
  - truncated APP0 payloads

## Validation

```sh
yarn test --run   # 168 tests pass
yarn build        # parcel build succeeds
yarn prettier --check src/markers/jfif.js tests/index.test.js
```

## Disclosure

I used GPT-5.5 and Claude (Fable) to help write and test this PR.

